### PR TITLE
Exchanged 'brainRegion' for 'brainLocation' property shape

### DIFF
--- a/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/brainslicing/v0.1.0.json
+++ b/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/brainslicing/v0.1.0.json
@@ -6,7 +6,6 @@
     "{{base}}/contexts/bbp/neurosciencegraph/core/v0.1.0",
     {
       "bbpactsh": "{{base}}/schemas/bbp/core/activity/v0.1.0/shapes/",
-      "bbptlotsh": "{{base}}/schemas/bbp/core/typedlabeledontologyterm/v0.1.0/shapes/",
       "bbpqsh": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/",
       "bbplocsh": "{{base}}/schemas/bbp/core/brainlocation/v0.1.0/shapes/",
       "this": "{{base}}/schemas/bbp/experiment/brainslicing/v0.1.0/shapes/"
@@ -45,10 +44,10 @@
               "minCount": 1
             },
             {
-              "path" : "nsg:brainRegion",
-              "name" : "Brain region",
-              "description" : "Brain region sliced",
-              "node":"bbptlotsh:BrainRegionOntologyTermShape"
+              "path" : "nsg:brainLocation",
+              "name" : "Brain location",
+              "description" : "Brain location information",
+              "node":"bbplocsh:BrainLocationShape"
             },
             {
               "path": "nsg:slicingPlane",


### PR DESCRIPTION
to normalize the usage of the brainLocation schema across bbp domains, the brainLocation
property shape was used to replace the brainRegion property shape in the BrainSlicing schema

Fixes #119 