### PR TITLE
Placed 'brainRegion' inside 'brainLocation' object in data instances

### DIFF
--- a/modules/bbp-experiment/src/test/resources/data/bbp/experiment/patchedcell/v0.1.0/min-fields.json
+++ b/modules/bbp-experiment/src/test/resources/data/bbp/experiment/patchedcell/v0.1.0/min-fields.json
@@ -9,8 +9,10 @@
         "nsg:PatchedCell"
     ],
     "name": "C010600A2-MT-C1",
-    "brainRegion": {
-        "@id": "http://www.FIXME.org/hbp_whs_sd_ontology/0000014",
-        "label": "Somatosensory cortex hindlimb layer IV"
+    "brainLocation": {
+        "brainRegion": {
+            "@id": "http://www.FIXME.org/hbp_whs_sd_ontology/0000014",
+            "label": "Somatosensory cortex hindlimb layer IV"
+        }
     }
 }

--- a/modules/bbp-experiment/src/test/resources/data/bbp/experiment/patchedcell/v0.1.0/min-fields.json
+++ b/modules/bbp-experiment/src/test/resources/data/bbp/experiment/patchedcell/v0.1.0/min-fields.json
@@ -11,7 +11,7 @@
     "name": "C010600A2-MT-C1",
     "brainLocation": {
         "brainRegion": {
-            "@id": "http://www.FIXME.org/hbp_whs_sd_ontology/0000014",
+            "@id": "http://www.FIXME.org/whs_sd_ontology/0000014",
             "label": "Somatosensory cortex hindlimb layer IV"
         }
     }

--- a/modules/bbp-experiment/src/test/resources/invalid/bbp/experiment/patchedcell/v0.1.0/wrong-type.json
+++ b/modules/bbp-experiment/src/test/resources/invalid/bbp/experiment/patchedcell/v0.1.0/wrong-type.json
@@ -8,8 +8,10 @@
         "nsg:WrongType"
     ],
     "name": "C010600A2-MT-C1",
-    "brainRegion": {
-        "@id": "http://www.FIXME.org/hbp_whs_sd_ontology/0000014",
-        "label": "Somatosensory cortex hindlimb layer IV"
+    "brainLocation": {
+        "brainRegion": {
+            "@id": "http://www.FIXME.org/whs_sd_ontology/0000014",
+            "label": "Somatosensory cortex hindlimb layer IV"
+        }
     }
 }


### PR DESCRIPTION
- placed 'brainRegion' inside 'brainLocation' object in valid min-fields data instance
- placed 'brainRegion' inside 'brainLocation' object in invalid wrong-type data instance
- changed 'brainRegion' '@id' value in both data instances

Fixes #121 