### PR TITLE
Adapted TraceGeneration, StimulusExperiment and PatchedCell schemas

### DIFF
--- a/modules/bbp-core/src/main/resources/contexts/bbp/neurosciencegraph/core/v0.1.0.json
+++ b/modules/bbp-core/src/main/resources/contexts/bbp/neurosciencegraph/core/v0.1.0.json
@@ -290,6 +290,129 @@
     "memodelRelease": {
       "@id": "nsg:memodelRelease",
       "@type": "@id"
+    },
+    "eType": {
+      "@id": "nsg:eType",
+      "@type": "@id"
+    },
+    "putativeEtype": {
+      "@id": "nsg:putativeEtype",
+      "@type": "@id"
+    },
+    "pipetteNumber": {
+      "@id": "nsg:pipetteNumber",
+      "@type": "@id"
+    },
+    "startMembranePotential": {
+      "@id": "nsg:startMembranePotential",
+      "@type": "@id"
+    },
+    "endMembranePotential": {
+      "@id": "nsg:endMembranePotential",
+      "@type": "@id"
+    },
+    "sealResistance": {
+      "@id": "nsg:sealResistance",
+      "@type": "@id"
+    },
+    "pipetteResistance": {
+      "@id": "nsg:pipetteResistance",
+      "@type": "@id"
+    },
+    "liquidJunctionPotential": {
+      "@id": "nsg:liquidJunctionPotential",
+      "@type": "@id"
+    },
+    "labelingCompound": {
+      "@id": "nsg:labelingCompound",
+      "@type": "@id"
+    },
+    "repetition": {
+      "@id": "nsg:repetition",
+      "@type": "@id"
+    },
+    "targetHoldingPotential": {
+      "@id": "nsg:targetHoldingPotential",
+      "@type": "@id"
+    },
+    "measuredHoldingPotential": {
+      "@id": "nsg:measuredHoldingPotential",
+      "@type": "@id"
+    },
+    "inputResistance": {
+      "@id": "nsg:inputResistance",
+      "@type": "@id"
+    },
+    "seriesResistance": {
+      "@id": "nsg:seriesResistance",
+      "@type": "@id"
+    },
+    "compensationCurrent": {
+      "@id": "nsg:compensationCurrent",
+      "@type": "@id"
+    },
+    "digitalToAnalogConverter": {
+      "@id": "nsg:digitalToAnalogConverter",
+      "@type": "@id"
+    },
+    "numberOfRepetition": {
+      "@id": "nsg:numberOfRepetition",
+      "@type": "@id"
+    },
+    "retrievalDate": {
+      "@id": "nsg:retrievalDate"
+    },
+    "timeStep": {
+      "@id": "nsg:timeStep",
+      "@type": "@id"
+    },
+    "slicingPlane": {
+      "@id": "nsg:slicingPlane",
+      "@type": "@id"
+    },
+    "slicingAngle": {
+      "@id": "nsg:slicingAngle",
+      "@type": "@id"
+    },
+    "cuttingThickness": {
+      "@id": "nsg:cuttingThickness",
+      "@type": "@id"
+    },
+    "hemisphere": {
+      "@id": "nsg:hemisphere",
+      "@type": "@id"
+    },
+    "solution": {
+      "@id": "nsg:solution",
+      "@type": "@id"
+    },
+    "materials": {
+      "@id": "nsg:materials",
+      "@type": "@id"
+    },
+    "vendor": {
+      "@id": "nsg:vendor",
+      "@type": "@id"
+    },
+    "steps": {
+      "@id": "nsg:steps",
+      "@type": "@id"
+    },
+    "warning": {
+      "@id": "nsg:warning",
+      "@type": "@id"
+    },
+    "reagentName": {
+      "@id": "nsg:reagentName",
+      "@type": "@id"
+    },
+    "reagentLinearFormula": {
+      "@id": "nsg:reagentLinearFormula",
+      "@type": "@id"
+    },
+    "reagentVendor": {
+      "@id": "nsg:reagentVendor",
+      "@type": "@id"
     }
   }
 }

--- a/modules/bbp-core/src/main/resources/schemas/bbp/core/measurement/v0.1.0.json
+++ b/modules/bbp-core/src/main/resources/schemas/bbp/core/measurement/v0.1.0.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "this": "{{base}}/schemas/bbp/core/measurement/v0.1.0/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "this:RepeatedQuantitativeMeasurementShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:RepeatedQuantitativeMeasurement",
+      "and": [
+        {
+          "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape"
+        },
+        {
+          "path": "nsg:numberOfRepetition",
+          "name": "Number of repetitions",
+          "datatype": "xsd:integer",
+          "minCount": 1,
+          "maxCount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/stimulusexperiment/v0.1.0.json
+++ b/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/stimulusexperiment/v0.1.0.json
@@ -24,20 +24,6 @@
         {
           "property": [
             {
-              "path": "nsg:providerExperimentId",
-              "name": "Provider experiment ID",
-              "description": "Laboratory identifier of the experiment",
-              "datatype": "xsd:string",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:providerExperimentName",
-              "name": "Provider experiment name",
-              "description": "Laboratory name of the experiment",
-              "datatype": "xsd:string",
-              "maxCount": 1
-            },
-            {
               "path": "nsg:stimulus",
               "name": "Stimulus",
               "description": "The shape of the stimulus",

--- a/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/trace/v0.1.0.json
+++ b/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/trace/v0.1.0.json
@@ -32,13 +32,6 @@
               "maxCount": 1
             },
             {
-              "path": "nsg:repetition",
-              "name": "Repetition",
-              "description": "Repetition number of trace",
-              "datatype": "xsd:integer",
-              "maxCount": 1
-            },
-            {
               "path": "nsg:channel",
               "name": "Channel",
               "description": "Channel number of trace",

--- a/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/tracegeneration/v0.1.0.json
+++ b/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/tracegeneration/v0.1.0.json
@@ -67,7 +67,7 @@
               "path": "nsg:measuredHoldingPotential",
               "name": "Measured holding potential",
               "description": "Measured holding potential of patched cell.",
-              "node": "this:MeasurementRepetitionShape",
+              "node": "{{base}}/schemas/bbp/core/measurement/v0.1.0/shapes/RepeatedQuantitativeMeasurementShape",
               "maxCount": 1
             },
             {
@@ -151,26 +151,6 @@
           "path": "schema:name",
           "name": "Name",
           "description": "Name of the converter",
-          "maxCount": 1
-        }
-      ]
-    },
-    {
-      "@id": "this:MeasurementRepetitionShape",
-      "@type": "sh:NodeShape",
-      "property": [
-        {
-          "path": "nsg:totalRepetitions",
-          "name": "Total repetitions",
-          "datatype": "xsd:float",
-          "minCount": 1,
-          "maxCount": 1
-        },
-        {
-          "path": "schema:value",
-          "name": "Measured value",
-          "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-          "minCount": 1,
           "maxCount": 1
         }
       ]

--- a/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/tracegeneration/v0.1.0.json
+++ b/modules/bbp-electrophysiology/src/main/resources/schemas/bbp/electrophysiology/tracegeneration/v0.1.0.json
@@ -22,20 +22,156 @@
             {
               "path": "prov:activity",
               "name": "Activity",
-              "description": "Points at stimulus experiment activity that generated trace",
+              "description": "Points at stimulus experiment activity that generated trace.",
               "class": "nsg:StimulusExperiment",
               "minCount": 1,
               "maxCount": 1
             },
             {
+              "path": "nsg:providerExperimentId",
+              "name": "Provider experiment ID",
+              "description": "Laboratory identifier of the experiment.",
+              "datatype": "xsd:string",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:providerExperimentName",
+              "name": "Provider experiment name",
+              "description": "Laboratory name of the experiment.",
+              "datatype": "xsd:string",
+              "maxCount": 1
+            },
+            {
               "path": "nsg:sweep",
               "name": "Sweep",
-              "description": "Sweep number of the trace",
+              "description": "Sweep number of the trace.",
               "datatype": "xsd:integer",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:repetition",
+              "name": "Repetition",
+              "description": "Repetition.",
+              "datatype": "xsd:integer",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:targetHoldingPotential",
+              "name": "Target holding potential",
+              "description": "Target holding potential of patched cell.",
+              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:measuredHoldingPotential",
+              "name": "Measured holding potential",
+              "description": "Measured holding potential of patched cell.",
+              "node": "this:MeasurementRepetitionShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:inputResistance",
+              "name": "Input resistance",
+              "description": "Input resistance of patched cell.",
+              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:seriesResistance",
+              "name": "Series resistance",
+              "description": "Series resistance compensation while patching cell.",
+              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:compensationCurrent",
+              "name": "Compensation current",
+              "description": "Compensation current for series resistance.",
+              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:analogToDigitalConverter",
+              "name": "Analog-to-digital converter settings",
+              "description": "Settings of analog-to-digital converter",
+              "node": "this:ConverterShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:digitalToAnalogConverter",
+              "name": "Digital-to-analog converter settings",
+              "description": "Settings of digital-to-analog converter",
+              "node": "this:DigitalToAnalogConverterShape",
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "this:DigitalToAnalogConverterShape",
+      "@type": "sh:NodeShape",
+      "and": [
+        {
+          "node": "this:ConverterShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:scale",
+              "name": "Scale",
+              "datatype": "xsd:float",
               "minCount": 1,
               "maxCount": 1
             }
           ]
+        }
+      ]
+    },
+    {
+      "@id": "this:ConverterShape",
+      "@type": "sh:NodeShape",
+      "property": [
+        {
+          "path": "schema:unitCode",
+          "name": "Unit",
+          "node": "{{base}}/schemas/bbp/core/typedlabeledontologyterm/v0.1.0/shapes/UnitCodeOntologyTermShape",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nsg:gain",
+          "name": "Gain",
+          "datatype": "xsd:float",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "schema:name",
+          "name": "Name",
+          "description": "Name of the converter",
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "this:MeasurementRepetitionShape",
+      "@type": "sh:NodeShape",
+      "property": [
+        {
+          "path": "nsg:totalRepetitions",
+          "name": "Total repetitions",
+          "datatype": "xsd:float",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "schema:value",
+          "name": "Measured value",
+          "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+          "minCount": 1,
+          "maxCount": 1
         }
       ]
     }

--- a/modules/bbp-electrophysiology/src/test/resources/data/bbp/electrophysiology/trace/v0.1.0/all-fields.json
+++ b/modules/bbp-electrophysiology/src/test/resources/data/bbp/electrophysiology/trace/v0.1.0/all-fields.json
@@ -12,7 +12,6 @@
     "providerId": "654363",
     "description": "Stimulation trace",
     "channel": "0",
-    "repetition": "2",
     "citation": "https://doi.org/10.1093/cercor/bhh092",
     "projectName": "Somatosensory cortex project",
     "retrievalDate": "2016-10-15T00:00:00",

--- a/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedcell/v0.1.0.json
+++ b/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedcell/v0.1.0.json
@@ -53,13 +53,6 @@
               "maxCount": 1
             },
             {
-              "path": "nsg:holdingPotential",
-              "name": "Holding potential",
-              "description": "Holding potential of patched cell",
-              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-              "maxCount": 1
-            },
-            {
               "path": "nsg:startMembranePotential",
               "name": "Start membrane potential",
               "description": "Membrane potential of patched cell at beginning",
@@ -88,38 +81,10 @@
               "maxCount": 1
             },
             {
-              "path": "nsg:inputResistance",
-              "name": "Input resistance",
-              "description": "Input resistance of patched cell",
-              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:seriesResistance",
-              "name": "Series resistance",
-              "description": "Series resistance while patching cell",
-              "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-              "maxCount": 1
-            },
-            {
               "path": "nsg:liquidJunctionPotential",
               "name": "Liquid junction potential",
               "description": "Liquid junction potential of patch",
               "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:analogToDigitalConverter",
-              "name": "Analog-to-digital converter settings",
-              "description": "Settings of analog-to-digital converter",
-              "node": "this:ConverterShape",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:digitalToAnalogConverter",
-              "name": "Digital-to-analog converter settings",
-              "description": "Settings of digital-to-analog converter",
-              "node": "this:DigitalToAnalogConverterShape",
               "maxCount": 1
             },
             {
@@ -134,47 +99,21 @@
       ]
     },
     {
-      "@id": "this:DigitalToAnalogConverterShape",
-      "@type": "sh:NodeShape",
-      "and": [
-        {
-          "node": "this:ConverterShape"
-        },
-        {
-          "property": [
-            {
-              "path": "nsg:scale",
-              "name": "Scale",
-              "datatype": "xsd:float",
-              "minCount": 1,
-              "maxCount": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "this:ConverterShape",
+      "@id": "this:MeasurementRepetitionShape",
       "@type": "sh:NodeShape",
       "property": [
         {
-          "path": "schema:unitCode",
-          "name": "Unit",
-          "node": "{{base}}/schemas/bbp/core/typedlabeledontologyterm/v0.1.0/shapes/UnitCodeOntologyTermShape",
-          "minCount": 1,
-          "maxCount": 1
-        },
-        {
-          "path": "nsg:gain",
-          "name": "Gain",
+          "path": "nsg:totalRepetitions",
+          "name": "Total repetitions",
           "datatype": "xsd:float",
           "minCount": 1,
           "maxCount": 1
         },
         {
-          "path": "schema:name",
-          "name": "Name",
-          "description": "Name of the converter",
+          "path": "schema:value",
+          "name": "Measured value",
+          "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
+          "minCount": 1,
           "maxCount": 1
         }
       ]

--- a/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedcell/v0.1.0.json
+++ b/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedcell/v0.1.0.json
@@ -97,26 +97,6 @@
           ]
         }
       ]
-    },
-    {
-      "@id": "this:MeasurementRepetitionShape",
-      "@type": "sh:NodeShape",
-      "property": [
-        {
-          "path": "nsg:totalRepetitions",
-          "name": "Total repetitions",
-          "datatype": "xsd:float",
-          "minCount": 1,
-          "maxCount": 1
-        },
-        {
-          "path": "schema:value",
-          "name": "Measured value",
-          "node": "{{base}}/schemas/bbp/core/quantitativevalue/v0.1.0/shapes/QuantitativeValueShape",
-          "minCount": 1,
-          "maxCount": 1
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
* Moved the following property shapes to TraceGeneration:
targetHoldingPotential
measuredHoldingPotential
inputResistance
seriesResistance
analogToDigitalConverter
digitalToAnalogConverter

* Added the following property shapes to TraceGeneration
repetition
compensationCurrent

Fixes #181 