### PR TITLE
Updated PatchedSlice and Protocol schema

### DIFF
--- a/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedslice/v0.1.0.json
+++ b/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/patchedslice/v0.1.0.json
@@ -24,10 +24,10 @@
         {
           "property": [
             {
-              "path": "nsg:brainRegion",
-              "name": "Brain region",
-              "description": "Brain region patched.",
-              "node": "{{base}}/schemas/bbp/core/typedlabeledontologyterm/v0.1.0/shapes/BrainRegionOntologyTermShape"
+              "path": "nsg:brainLocation",
+              "name": "Brain location",
+              "description": "Brain location information of the patchedcell",
+              "node": "{{base}}/schemas/bbp/core/brainlocation/v0.1.0/shapes/BrainLocationShape"
             },
             {
               "path": "dcterms:hasPart",

--- a/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/protocol/v0.1.0.json
+++ b/modules/bbp-experiment/src/main/resources/schemas/bbp/experiment/protocol/v0.1.0.json
@@ -44,7 +44,14 @@
           "path": "schema:author",
           "name": "Author",
           "description": "Author of the protocol",
-          "class": "nsg:Agent"
+          "xone": [
+            {
+              "node": "{{base}}/schemas/bbp/core/person/v0.1.0/shapes/PersonShape"
+            },
+            {
+              "node": "{{base}}/schemas/bbp/core/organization/v0.1.0/shapes/OrganizationShape"
+            }
+          ]
         },
         {
           "path": "nsg:vendor",


### PR DESCRIPTION
* Used brainLocation property shape instead of brainRegion property shape in PatchedSlice schema
* Defined author property shape in Protocol schema to conform to Organization or Person shape

Fixes #188  and #187 